### PR TITLE
Fix for missing Powershell modules and dependencies: 7zip!

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,17 +7,7 @@
     - boost
     - b2
 
-- name: Ensure the required NuGet package provider version is installed
-  # yamllint disable-line rule:line-length
-  win_shell: Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies -Force
-
-- name: Install PowerShell Community Extensions
-  win_psmodule:
-    name: Pscx
-    state: present
-    allow_clobber: true
-
-- name: Install utilities
+- name: Just install 7zip instead of Pscx to deal with tar.gz
   win_chocolatey:
     name: "{{ item }}"
     state: present
@@ -48,7 +38,7 @@
   tags:
     - zlib
 
-- name: gunzip lzib source
+- name: unzip lzib source
   win_unzip:
     src: "{{ download_zlib.dest }}"
     dest: "{{ boost_prefix }}"
@@ -81,13 +71,10 @@
     - bzip2
 
 - name: unpack bzip2 source
-  win_unzip:
-    src: "{{ download_bzip2.dest }}"
-    dest: "{{ boost_prefix }}"
-    delete_archive: true
-    recurse: true
+  win_shell: '7z x "{{ download_bzip2.dest }}" -so | 7z x -aoa -si -ttar -o"{{ boost_prefix }}"'
+  args:
     creates: "{{ boost_prefix }}/bzip2-{{ bzip2_version }}"
-    copy: false
+    chdir: "{{ boost_workdir }}"
   tags:
     - bzip2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,8 @@
 
 - name: Just install 7zip instead of Pscx to deal with tar.gz
   win_chocolatey:
-    name: "{{ item }}"
+    name: 7zip.install
     state: present
-  with_items:
-    - 7zip.install
   register: install_7zip
   until: install_7zip is succeeded
   retries: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,17 +41,7 @@
     src: "{{ download_zlib.dest }}"
     dest: "{{ boost_prefix }}"
     delete_archive: true
-    creates: "{{ boost_prefix }}/zlib-{{ zlib_version }}.tar"
-    copy: false
-  tags:
-    - zlib
-
-- name: untar lzib source
-  win_unzip:
-    src: "{{ boost_prefix }}/zlib-{{ zlib_version }}.tar"
-    dest: "{{ boost_prefix }}"
-    delete_archive: true
-    creates: "{{ boost_prefix }}/zlib-{{ zlib_version }}"
+    creates: "{{ boost_prefix }}/zlib-{{ zlib_version }}/contrib"
     copy: false
   tags:
     - zlib
@@ -69,7 +59,7 @@
     - bzip2
 
 - name: unpack bzip2 source
-  win_shell: '7z x "{{ download_bzip2.dest }}" -so | 7z x -aoa -si -ttar -o"{{ boost_prefix }}"'
+  win_shell: '7z x -r "{{ download_bzip2.dest }}" -so | 7z x -aoa -si -ttar -o"{{ boost_prefix }}"'
   args:
     creates: "{{ boost_prefix }}/bzip2-{{ bzip2_version }}"
     chdir: "{{ boost_workdir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,13 +58,16 @@
   tags:
     - bzip2
 
-- name: unpack bzip2 source
-  win_shell: '7z x -r "{{ download_bzip2.dest }}" -so | 7z x -aoa -si -ttar -o"{{ boost_prefix }}"'
+- name: gunzip bzip2 source
+  win_shell: '7z x "{{ download_bzip2.dest }}" -o"{{ boost_workdir }}"'
   args:
-    creates: "{{ boost_prefix }}/bzip2-{{ bzip2_version }}"
+    creates: "{{ boost_prefix }}/bzip2-{{ bzip2_version }}.tar"
     chdir: "{{ boost_workdir }}"
   tags:
     - bzip2
+
+- name: untar bzip2 source
+  win_shell: '7z x -aoa -ttar -r -o"{{ boost_prefix }}" "{{ boost_workdir }}/bzip2-{{ bzip2_version }}.tar"'
 
 - name: cleanup temporary files
   win_file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
   tags:
     - zlib
 
-- name: unzip lzib source
+- name: unzip zlib source
   win_unzip:
     src: "{{ download_zlib.dest }}"
     dest: "{{ boost_prefix }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,8 +6,8 @@ boost_url: "{{ boost_site }}/{{ boost_version }}/source/{{ boost_dest }}.{{ boos
 # yamllint disable-line rule:line-length
 boost_bin: "{{ boost_site }}/{{ boost_version }}/binaries/{{ boost_file_name_exe }}"
 
-zlib_lib: "zlib-{{ zlib_version }}"
-zlib_archive: "{{ zlib_lib }}.tar.gz"
+zlib_lib: "zlib{{ zlib_version.replace('.', '')  }}"
+zlib_archive: "{{ zlib_lib }}.zip"
 zlib_url: "http://zlib.net/{{ zlib_archive }}"
 bzip2_site: "https://www.sourceware.org/pub/bzip2"
 bzip2_file: "bzip2-{{ bzip2_version }}.tar.gz"


### PR DESCRIPTION
My laptop fans are spinning again, compiling Boost on windows! This PR avoids windows powershell dependcy installation by by downloading zlib as a zip file instead of a tar.gz, and by using 7zip to unpack bzip tar.gz instead of (outdated?) `win_unzip:` ansible module.